### PR TITLE
Persist timer state via GameManager

### DIFF
--- a/Cg_2d_game/Assets/Scripts/Timer.cs
+++ b/Cg_2d_game/Assets/Scripts/Timer.cs
@@ -27,6 +27,7 @@ public class Timer : MonoBehaviour
     void Start()
     {
         //TimerReset();
+        stopTime = GameManager.instance?.GlobalTime1 ?? 0f;
         TimerStart();
     }
 
@@ -70,6 +71,10 @@ public class Timer : MonoBehaviour
     void Update()
     {
         timerTime = stopTime + (Time.time - startTime);
+        if (isRunning && GameManager.instance != null)
+        {
+            GameManager.instance.GlobalTime1 = timerTime;
+        }
         int minutesInt = (int)timerTime / 60;
         int secondsInt = (int)timerTime % 60;
         int seconds100Int = (int)(Mathf.Floor((timerTime - (secondsInt + minutesInt * 60)) * 100));


### PR DESCRIPTION
## Summary
- restore the timer's accumulated stop time from the GameManager when the timer starts
- persist the running timer's elapsed time back to the GameManager while active

## Testing
- not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cdc05c90f0832a8b75632821229182