### PR TITLE
Integrate global timer persistence across scenes

### DIFF
--- a/Cg_2d_game/Assets/Scripts/LoaderScenes.cs
+++ b/Cg_2d_game/Assets/Scripts/LoaderScenes.cs
@@ -3,20 +3,31 @@ using UnityEngine.SceneManagement;
 
 public class LoaderScenes : MonoBehaviour
 {
+    [SerializeField] private GameControllerScene1 gameControllerScene1;
+
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
     {
-        
+        if (gameControllerScene1 == null)
+        {
+            gameControllerScene1 = FindObjectOfType<GameControllerScene1>();
+        }
     }
 
     // Update is called once per frame
     void Update()
     {
-        
+
     }
     public void lectorEscena(string nameScene)
     {
-        //añadir aca un metodo para devolver el valor del tiempo que llevamos y lo devolvemos al timer
-        SceneManager.LoadScene(nameScene);
+        if (gameControllerScene1 != null)
+        {
+            gameControllerScene1.IrAEscena(nameScene);
+        }
+        else
+        {
+            SceneManager.LoadScene(nameScene);
+        }
     }
 }

--- a/Cg_2d_game/Assets/Scripts/Scene1/GameControllerScene1.cs
+++ b/Cg_2d_game/Assets/Scripts/Scene1/GameControllerScene1.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class GameControllerScene1 : MonoBehaviour
 {
@@ -6,12 +7,26 @@ public class GameControllerScene1 : MonoBehaviour
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
     {
-        
+        if (tiempoEscena != null && GameManager.instance != null)
+        {
+            tiempoEscena.InitializeFromGlobal(GameManager.instance.GlobalTime1);
+            tiempoEscena.TimerStart();
+        }
     }
 
     // Update is called once per frame
     void Update()
     {
-        
+
+    }
+
+    public void IrAEscena(string sceneName)
+    {
+        if (tiempoEscena != null && GameManager.instance != null)
+        {
+            tiempoEscena.TimerStop();
+            GameManager.instance.GlobalTime1 = tiempoEscena.CurrentTime;
+        }
+        SceneManager.LoadScene(sceneName);
     }
 }

--- a/Cg_2d_game/Assets/Scripts/Scene2/GameControllerScene2.cs
+++ b/Cg_2d_game/Assets/Scripts/Scene2/GameControllerScene2.cs
@@ -6,7 +6,11 @@ public class GameControllerScene2 : MonoBehaviour
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
     {
-
+        if (tiempoEscena != null && GameManager.instance != null)
+        {
+            tiempoEscena.InitializeFromGlobal(GameManager.instance.GlobalTime1);
+            tiempoEscena.TimerStart();
+        }
     }
 
     // Update is called once per frame

--- a/Cg_2d_game/Assets/Scripts/Timer.cs
+++ b/Cg_2d_game/Assets/Scripts/Timer.cs
@@ -26,8 +26,8 @@ public class Timer : MonoBehaviour
     // Use this for initialization
     void Start()
     {
-        //TimerReset();
-        TimerStart();
+        // La inicializaciÃ³n del temporizador se realiza desde los GameController
+        // para permitir reanudar tiempos globales entre escenas.
     }
 
     public void TimerStart()
@@ -38,8 +38,6 @@ public class Timer : MonoBehaviour
             isRunning = true;
             startTime = Time.time;
         }
-
-        //crear un else donde reciba el valor del tiempo cambiado en el loaderscenes para empezar un timer a partir del tiempo que ya llevamos
     }
 
     public void TimerStop()
@@ -56,7 +54,7 @@ public class Timer : MonoBehaviour
             //    respuestaAudio.clip = stop;
             //    respuestaAudio.Play();
             //}
-            //añadir un return para que pueda pasarle el dato del tiempo total hasta que se pause el tiempo a gamemanager
+            //aadir un return para que pueda pasarle el dato del tiempo total hasta que se pause el tiempo a gamemanager
         }
     }
 
@@ -64,23 +62,38 @@ public class Timer : MonoBehaviour
     {
         print("RESET");
         stopTime = 0;
+        timerTime = 0;
         isRunning = false;
         timerMinutes.text = timerSeconds.text = timerSeconds100.text = "00";
     }
 
+    public void InitializeFromGlobal(float timeValue)
+    {
+        stopTime = timeValue;
+        timerTime = timeValue;
+        UpdateDisplay(timerTime);
+    }
+
+    public float CurrentTime => timerTime;
+
     // Update is called once per frame
     void Update()
     {
-        timerTime = stopTime + (Time.time - startTime);
-        int minutesInt = (int)timerTime / 60;
-        int secondsInt = (int)timerTime % 60;
-        int seconds100Int = (int)(Mathf.Floor((timerTime - (secondsInt + minutesInt * 60)) * 100));
-
         if (isRunning)
         {
-            timerMinutes.text = (minutesInt < 10) ? "0" + minutesInt : minutesInt.ToString();
-            timerSeconds.text = (secondsInt < 10) ? "0" + secondsInt : secondsInt.ToString();
-            timerSeconds100.text = (seconds100Int < 10) ? "0" + seconds100Int : seconds100Int.ToString();
+            timerTime = stopTime + (Time.time - startTime);
+            UpdateDisplay(timerTime);
         }
+    }
+
+    private void UpdateDisplay(float displayTime)
+    {
+        int minutesInt = (int)displayTime / 60;
+        int secondsInt = (int)displayTime % 60;
+        int seconds100Int = (int)(Mathf.Floor((displayTime - (secondsInt + minutesInt * 60)) * 100));
+
+        timerMinutes.text = (minutesInt < 10) ? "0" + minutesInt : minutesInt.ToString();
+        timerSeconds.text = (secondsInt < 10) ? "0" + secondsInt : secondsInt.ToString();
+        timerSeconds100.text = (seconds100Int < 10) ? "0" + seconds100Int : seconds100Int.ToString();
     }
 }


### PR DESCRIPTION
## Summary
- allow the Timer component to initialize from a persisted time value and expose the current time
- hook Scene 1 controller and loader into the timer so the global clock is paused and resumed when changing scenes
- resume the timer in Scene 2 using the global time value for a seamless display

## Testing
- not run (Unity automated tests not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cdcf2d4e9c832aa1bbe6f8a220d59a