### PR TITLE
Record timer time when changing scenes

### DIFF
--- a/Cg_2d_game/Assets/Scripts/LoaderScenes.cs
+++ b/Cg_2d_game/Assets/Scripts/LoaderScenes.cs
@@ -3,20 +3,65 @@ using UnityEngine.SceneManagement;
 
 public class LoaderScenes : MonoBehaviour
 {
+    [SerializeField]
+    private Timer activeTimer;
+
+    private void Awake()
+    {
+        EnsureTimerReference();
+    }
+
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
     {
-        
+
     }
 
     // Update is called once per frame
     void Update()
     {
-        
+
     }
     public void lectorEscena(string nameScene)
     {
-        //añadir aca un metodo para devolver el valor del tiempo que llevamos y lo devolvemos al timer
+        EnsureTimerReference();
+        if (activeTimer != null)
+        {
+            activeTimer.TimerStop();
+
+            float currentTotal = activeTimer.CurrentTime;
+            GameManager manager = GameManager.instance;
+            if (manager != null)
+            {
+                float previousTotal = manager.GlobalTime1;
+                float delta = currentTotal - previousTotal;
+                if (delta < 0f)
+                {
+                    delta = currentTotal;
+                }
+                manager.SumaTimeGlobal(delta);
+            }
+            else
+            {
+                Debug.LogWarning("LoaderScenes: GameManager instance not found when recording time.");
+            }
+
+            activeTimer.TimerReset();
+            activeTimer = null;
+        }
+        else
+        {
+            Debug.LogWarning("LoaderScenes: No Timer found to record time before loading scene.");
+        }
+
         SceneManager.LoadScene(nameScene);
+    }
+
+    private void EnsureTimerReference()
+    {
+        if (activeTimer == null)
+        {
+            activeTimer = FindObjectOfType<Timer>();
+        }
     }
 }

--- a/Cg_2d_game/Assets/Scripts/Scene1/GameControllerScene1.cs
+++ b/Cg_2d_game/Assets/Scripts/Scene1/GameControllerScene1.cs
@@ -6,12 +6,35 @@ public class GameControllerScene1 : MonoBehaviour
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
     {
-        
+        if (tiempoEscena == null)
+        {
+            tiempoEscena = GetComponent<Timer>();
+        }
+
+        if (tiempoEscena != null)
+        {
+            float resumeTime = 0f;
+            if (GameManager.instance != null)
+            {
+                resumeTime = GameManager.instance.GlobalTime1;
+            }
+            else
+            {
+                Debug.LogWarning("GameControllerScene1: GameManager instance not found when initializing timer.");
+            }
+
+            tiempoEscena.InitializeFromGlobal(resumeTime);
+            tiempoEscena.TimerStart();
+        }
+        else
+        {
+            Debug.LogWarning("GameControllerScene1: Timer reference is missing.");
+        }
     }
 
     // Update is called once per frame
     void Update()
     {
-        
+
     }
 }

--- a/Cg_2d_game/Assets/Scripts/Scene2/GameControllerScene2.cs
+++ b/Cg_2d_game/Assets/Scripts/Scene2/GameControllerScene2.cs
@@ -6,7 +6,30 @@ public class GameControllerScene2 : MonoBehaviour
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
     {
+        if (tiempoEscena == null)
+        {
+            tiempoEscena = GetComponent<Timer>();
+        }
 
+        if (tiempoEscena != null)
+        {
+            float resumeTime = 0f;
+            if (GameManager.instance != null)
+            {
+                resumeTime = GameManager.instance.GlobalTime1;
+            }
+            else
+            {
+                Debug.LogWarning("GameControllerScene2: GameManager instance not found when initializing timer.");
+            }
+
+            tiempoEscena.InitializeFromGlobal(resumeTime);
+            tiempoEscena.TimerStart();
+        }
+        else
+        {
+            Debug.LogWarning("GameControllerScene2: Timer reference is missing.");
+        }
     }
 
     // Update is called once per frame


### PR DESCRIPTION
## Summary
- capture the active Timer in LoaderScenes before changing scenes and record elapsed time to the GameManager safely
- reset the timer after switching scenes to prevent double counting and gracefully handle missing references
- resume scene timers from the stored global time when Scene1 and Scene2 controllers start, with safeguards for missing references

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68cdd6128d7c832abefcbc2922bc9dc8